### PR TITLE
Update models and API base URL in `feature/open-router`

### DIFF
--- a/app/routes/billing_routes.py
+++ b/app/routes/billing_routes.py
@@ -33,7 +33,10 @@ os.environ["LANGSMITH_DEBUG"] = "true"
 
 
 # OpenAI-Key
-async_client = wrap_openai(AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY")))
+async_client = wrap_openai(AsyncOpenAI(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url="https://openrouter.ai/api/v1"
+))
 
 router = APIRouter()  
 
@@ -56,7 +59,7 @@ async def extract_dims_gpt(line: str) -> dict:
         "Antworte nur mit JSON, z.B. {\"L\": 5.0, \"B\": 1.0, \"T\": 2.0}"
     )
     resp = await async_client.chat.completions.create(
-        model            = "gpt-4o-mini",
+        model            = "openai/gpt-4o-mini",
         temperature      = 0.0,
         response_format  = {"type": "json_object"},
         messages = [

--- a/app/services/lv_matcher.py
+++ b/app/services/lv_matcher.py
@@ -23,7 +23,10 @@ os.getenv("LANGSMITH_PROJECT")
 os.environ["LANGSMITH_DEBUG"] = "true"
 
 # OpenAI-Key
-async_client = wrap_openai(AsyncOpenAI(api_key=os.getenv("OPENAI_API_KEY")))
+async_client = wrap_openai(AsyncOpenAI(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url="https://openrouter.ai/api/v1"
+))
 
 CATALOG: List[Dict[str, Any]] = load_lv()
 
@@ -94,7 +97,7 @@ async def _match_line(line: str, hint: Dict[str, Any] | None = None) -> Dict[str
     )
 
     resp = await async_client.chat.completions.create(
-        model="gpt-4o-mini",
+        model="openai/gpt-4o-mini",
         temperature=0.0,
         response_format={"type": "json_object"},
         messages=[{"role": "system", "content": SYSTEM_PROMPT},

--- a/main.py
+++ b/main.py
@@ -886,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "openai/codex-mini",
+        model            = "openai/gpt-3.5-turbo-instruct",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1763,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="openai/codex-mini",
+            model="openai/gpt-3.5-turbo-instruct",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1861,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="openai/codex-mini",
+            model="openai/gpt-3.5-turbo-instruct",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},

--- a/main.py
+++ b/main.py
@@ -886,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "wandb/bf16",
+        model            = "qwen/qwen3-coder",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1763,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="wandb/bf16",
+            model="qwen/qwen3-coder",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1861,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="wandb/bf16",
+            model="qwen/qwen3-coder",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},

--- a/main.py
+++ b/main.py
@@ -886,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "openai/gpt-5-nano",
+        model            = "openai/gpt-5",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1763,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-5-nano",
+            model="openai/gpt-5",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1861,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-5-nano",
+            model="openai/gpt-5",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},

--- a/main.py
+++ b/main.py
@@ -886,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "openai/gpt-3.5-turbo-0125",
+        model            = "openai/gpt-5-nano",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1763,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-3.5-turbo-0125",
+            model="openai/gpt-5-nano",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1861,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-3.5-turbo-0125",
+            model="openai/gpt-5-nano",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},

--- a/main.py
+++ b/main.py
@@ -886,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "openai/gpt-5",
+        model            = "openai/codex-mini",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1763,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-5",
+            model="openai/codex-mini",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1861,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-5",
+            model="openai/codex-mini",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},

--- a/main.py
+++ b/main.py
@@ -886,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "openai/gpt-3.5-turbo",
+        model            = "wandb/bf16",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1763,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-3.5-turbo",
+            model="wandb/bf16",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1861,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-3.5-turbo",
+            model="wandb/bf16",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},

--- a/main.py
+++ b/main.py
@@ -886,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "openai/gpt-3.5-turbo-instruct",
+        model            = "openai/gpt-3.5-turbo",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1763,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-3.5-turbo-instruct",
+            model="openai/gpt-3.5-turbo",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1861,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="openai/gpt-3.5-turbo-instruct",
+            model="openai/gpt-3.5-turbo",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},

--- a/main.py
+++ b/main.py
@@ -46,7 +46,10 @@ os.environ["LANGSMITH_DEBUG"] = "true"
 
 
 # OpenAI-Key
-client = wrap_openai(OpenAI(api_key=os.getenv("OPENAI_API_KEY")))
+client = wrap_openai(OpenAI(
+    api_key=os.getenv("OPENAI_API_KEY"),
+    base_url="https://openrouter.ai/api/v1",
+))
 
 # CORS, falls nötig
 app.add_middleware(
@@ -883,7 +886,7 @@ ANTWORTFORMAT  (genau so!)
 """
 
     resp = client.chat.completions.create(
-        model            = "gpt-3.5-turbo-0125",
+        model            = "openai/gpt-3.5-turbo-0125",
         response_format  = {"type": "json_object"},
         temperature      = 0.0,
         max_tokens       = 500,
@@ -1760,7 +1763,7 @@ def edit_element(session_id: str, instruction: str = Body(..., embed=True)):
 
     try:
         response = client.chat.completions.create(
-            model="gpt-3.5-turbo-0125",
+            model="openai/gpt-3.5-turbo-0125",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},
@@ -1858,7 +1861,7 @@ ANTWORTFORMAT (exakt so!):
 
     try:
         response = client.chat.completions.create(
-            model="gpt-3.5-turbo-0125",
+            model="openai/gpt-3.5-turbo-0125",
             response_format={"type": "json_object"},
             messages=[
                 {"role": "system", "content": "You are a JSON API."},


### PR DESCRIPTION
```
- Standardized chat completion models to `qwen/qwen3-coder`,
- Updated OpenAI API base URL to OpenRouter for consistency.
```